### PR TITLE
Fixing `train_batch_size` and `eval_batch_size` arg

### DIFF
--- a/finetune-distilbert.ipynb
+++ b/finetune-distilbert.ipynb
@@ -319,7 +319,7 @@
     "```\n",
     "When you create a SageMaker training job, SageMaker takes care of starting and managing all the required compute instances with the `huggingface` container, uploads the provided fine-tuning script `train.py` and downloads the data from our `sagemaker_session_bucket` into the container local storage at `/opt/ml/input/data`. Then, it starts the training job by running. \n",
     "```python\n",
-    "/opt/conda/bin/python train.py --epochs 5 --model_name distilbert-base-cased --token_name distilbert-base-cased --train_batch_size 128\n",
+    "/opt/conda/bin/python train.py --epochs 5 --model_name distilbert-base-cased --token_name distilbert-base-cased --train_batch_size 32\n",
     "```\n",
     "\n",
     "The `hyperparameters` you define in the `HuggingFace` estimator are passed in as named arguments. The training script expect the `HuggingFace` model and token name so it can retrieve them.\n",
@@ -384,7 +384,7 @@
    "outputs": [],
    "source": [
     "hyperparameters={'epochs': 3,\n",
-    "                 'train_batch_size': 128,\n",
+    "                 'train_batch_size': 32,\n",
     "                 'model_name': model_name,\n",
     "                 'tokenizer_name': tokenizer_name,\n",
     "                 'output_dir':'/opt/ml/checkpoints',\n",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -16,8 +16,8 @@ if __name__ == "__main__":
 
     # hyperparameters sent by the client are passed as command-line arguments to the script.
     parser.add_argument("--epochs", type=int, default=3)
-    parser.add_argument("--train-batch-size", type=int, default=32)
-    parser.add_argument("--eval-batch-size", type=int, default=64)
+    parser.add_argument("--train_batch_size", type=int, default=32)
+    parser.add_argument("--eval_batch_size", type=int, default=64)
     parser.add_argument("--warmup_steps", type=int, default=500)
     parser.add_argument("--model_name", type=str)
     parser.add_argument("--tokenizer_name", type=str)


### PR DESCRIPTION
# What does this PR do? 

This PR fixes the cli args for `train_batch_size` and `eval_batch_size`, since the `hyperparameter` key `train_batch_size` won't get parsed by the parser argument `train-batch-size`